### PR TITLE
fix(client): checkInData를 제대로 받아오지 못할 경우 다시 받아오게 수정

### DIFF
--- a/client.py
+++ b/client.py
@@ -179,6 +179,16 @@ class Client:
 
         bookingData = booking.getBookingData().toJsonBody()
 
+        print("Bringing check in data... ", end='')
+        while True:
+            check_in_data = get_check_in_data(booking_data["ticket"]["lsl"][0],
+                                              booking_data["wifi"]["ports"][0]).to_json_body()
+            if "host" in check_in_data:
+                print("Finished")
+                break
+            else:
+                await asyncio.sleep(random.randint(100, 150) / 100)
+
         checkInData = checkIn.getCheckInData(
             bookingData["ticket"]["lsl"][0],
             bookingData["wifi"]["ports"][0]).toJsonBody()


### PR DESCRIPTION
checkInData를 제대로 받아오지 못해 바로 아래에서 key에러가 자주 발생합니다.
해당 오류를 수정하고자 제대로 받아올때까지 반복하는 코드를 추가했습니다.